### PR TITLE
updating parsing

### DIFF
--- a/sonic_platform_base/sonic_pcie/pcie_common.py
+++ b/sonic_platform_base/sonic_pcie/pcie_common.py
@@ -37,9 +37,9 @@ class PcieUtil(PcieBase):
     def get_pcie_device(self):
         pciDict = {}
         pciList = []
-        p1 = "^(\w+):(\w+)\.(\w)\s(.*)\s\(.*\)"
-        p2 = "^.*:.*:.*:(\w+)\s\(.*\)"
-        command1 = "sudo lspci"
+        p1 = "^(\w+):(\w+):(\w+)\.(\w)\s(.*)\s*\(*.*\)*"
+        p2 = "^.*:.*:.*:(\w+)\s*\(*.*\)*"
+        command1 = "sudo lspci -D"
         command2 = "sudo lspci -n"
         # run command 1
         proc1 = subprocess.Popen(command1, shell=True, stdout=subprocess.PIPE)
@@ -64,10 +64,10 @@ class PcieUtil(PcieBase):
                 match1 = re.search(p1, line1.strip())
                 match2 = re.search(p2, line2.strip())
                 if match1 and match2:
-                    Bus = match1.group(1)
-                    Dev = match1.group(2)
-                    Fn = match1.group(3)
-                    Name = match1.group(4)
+                    Bus = match1.group(2)
+                    Dev = match1.group(3)
+                    Fn = match1.group(4)
+                    Name = match1.group(5)
                     Id = match2.group(1)
                     pciDict["name"] = Name
                     pciDict["bus"] = Bus

--- a/sonic_platform_base/sonic_pcie/pcie_common.py
+++ b/sonic_platform_base/sonic_pcie/pcie_common.py
@@ -64,11 +64,13 @@ class PcieUtil(PcieBase):
                 match1 = re.search(p1, line1.strip())
                 match2 = re.search(p2, line2.strip())
                 if match1 and match2:
+                    Domain = match1.group(1)
                     Bus = match1.group(2)
                     Dev = match1.group(3)
                     Fn = match1.group(4)
                     Name = match1.group(5)
                     Id = match2.group(1)
+                    pciDict["domain"] = Domain
                     pciDict["name"] = Name
                     pciDict["bus"] = Bus
                     pciDict["dev"] = Dev
@@ -89,18 +91,26 @@ class PcieUtil(PcieBase):
         curInfo = self.get_pcie_device()
         for item_conf in self.confInfo:
             flag = 0            
+	    if "domain" in item_conf:
+                domain_conf = item_conf["domain"]
+            else:
+                domain_conf = "0000"
             bus_conf = item_conf["bus"]
             dev_conf = item_conf["dev"]
             fn_conf = item_conf["fn"]
             name_conf = item_conf["name"]
             id_conf = item_conf["id"]
             for item_cur in curInfo:
+                if "domain" in item_cur:
+                    domain_cur = item_cur["domain"]
+                else:
+                    domain_cur = "0000"
                 bus_cur = item_cur["bus"]
                 dev_cur = item_cur["dev"]
                 fn_cur = item_cur["fn"]
                 name_cur = item_cur["name"]
                 id_cur = item_cur["id"]
-                if bus_cur == bus_conf and dev_cur == dev_conf and \
+                if domain_cur == domain_conf and bus_cur == bus_conf and dev_cur == dev_conf and \
                    fn_cur == fn_conf and name_cur == name_conf and \
                    id_cur == id_conf:
                    flag+=1


### PR DESCRIPTION

TG48M-P
root@sonic:/# pcieutil pcie-show
==============================Display PCIe Device===============================
bus:dev.fn 00:00.0 - dev_id=0x0110,  PCI bridge: Marvell Technology Group Ltd. Device 0110
bus:dev.fn 01:00.0 - dev_id=0xc80c,  Ethernet controller: Marvell Technology Group Ltd. Device c80c
bus:dev.fn 00:00.0 - dev_id=0x0110,  PCI bridge: Marvell Technology Group Ltd. Device 0110
bus:dev.fn 01:00.0 - dev_id=0xc80c,  Ethernet controller: Marvell Technology Group Ltd. Device c80c

TG4810M:

pcieutil pcie-show
==============================Display PCIe Device===============================
bus:dev.fn 00:00.0 - dev_id=0x0110,  PCI bridge: Marvell Technology Group Ltd. Device 0110
bus:dev.fn 01:00.0 - dev_id=0xcc1e,  Ethernet controller: Marvell Technology Group Ltd. Device cc1e
